### PR TITLE
fix: stabilize version to 3.12.0 (unblocks poetry lock in rasa-actions)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rasa-sdk"
-version = "3.12.0.dev2"
+version = "3.12.0"
 description = "Open source machine learning framework to automate text- and voice-based conversations: NLU, dialogue management, connect to Slack, Facebook, and more - Create chatbots and voice assistants"
 authors = [ "Rasa Technologies GmbH <hi@rasa.com>",]
 maintainers = [ "Tom Bocklisch <tom@rasa.com>",]


### PR DESCRIPTION
## Summary

- Bumps `version` from `3.12.0.dev2` → `3.12.0` in `pyproject.toml`

## Why

The `.dev2` pre-release suffix causes poetry to refuse resolving `rasa-sdk` as a satisfiable dependency when declared as a git source in `caire-services/services/rasa-actions`. This makes `poetry lock` fail with:

```
[BUG] rasa-sdk (3.12.0.dev2) @ git+https://github.com/caire-health/rasa-sdk.git@main is not satisfied.
```

This blocks lock regeneration in `rasa-actions`, which in turn prevents CVE floor pins (gitpython >=3.1.58, nltk >=3.9.5, soupsieve >=2.8.4, pyasn1 >=0.6.4, pillow >=12.3.0, pypdf >=6.14.2, aiohttp >=3.14.3) from taking effect in the resolved lock file.

## After merging

Once this is merged, `caire-services/services/rasa-actions/` needs a `poetry lock` run to regenerate the lock file and pick up the new commit SHA + resolve all floor pins.



 Step 1 — Verify the rasa-sdk merge landed

  cd /Users/ileanatoneva/Documents/Projects/rasa-sdk
  git fetch origin
  git log --oneline origin/main -3
  grep '^version' pyproject.toml   # should show 3.12.0

  Step 2 — Switch to the caire-services PR branch

  cd /Users/ileanatoneva/Documents/Projects/caire-services
  git fetch origin
  git checkout CRE-5152/vanta-cve-lock-file-fixes
  git pull

  Step 3 — Regenerate rasa-actions poetry.lock

  cd /Users/ileanatoneva/Documents/Projects/caire-services/services/rasa-actions
  poetry lock
  Expected: resolves cleanly. Verify the floor pins took effect:
  grep -A1 'name = "gitpython"\|name = "nltk"\|name = "soupsieve"\|name = "pyasn1"\|name = "pillow"\|name = "pypdf"\|name = "aiohttp"' poetry.lock | grep version
  Expected versions: gitpython=3.1.58, nltk≥3.9.5, soupsieve≥2.8.4, pyasn1≥0.6.4, pillow≥12.3.0, pypdf≥6.14.2, aiohttp≥3.14.3

  Step 4 — Update the rasa-actions resolved_reference

  The lock will also pick up the new rasa-sdk commit SHA automatically. Confirm it changed:
  grep "resolved_reference" poetry.lock

  Step 5 — Commit and push to PR #3385

  cd /Users/ileanatoneva/Documents/Projects/caire-services
  git add services/rasa-actions/poetry.lock
  git commit -m "$(cat <<'EOF'
  fix(cve): regenerate rasa-actions lock after rasa-sdk version stabilized

  poetry lock now resolves cleanly with rasa-sdk 3.12.0 (was blocked by
  3.12.0.dev2 pre-release). Floor pins for gitpython/nltk/soupsieve/
  pyasn1/pillow/pypdf/aiohttp now take effect in the resolved lock.

  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  EOF
  )"
  git push

  Step 6 — Confirm on PR #3385

  Check https://github.com/caire-health/caire-services/pull/3385 — the new commit should appear and CI should pass for rasa-actions.
  
## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)