### PR TITLE
fix: bump httpx ^0.27 → ^0.28 to unblock rasa-actions lock resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ certifi = "^2024.8"
 googleapis-common-protos = "^1.65"
 h11 = "0.16.0"
 httpcore = "^1"
-httpx  = "^0.27"
+httpx  = "^0.28"
 
 [tool.poetry.dev-dependencies]
 pytest-cov = "^4.1.0"


### PR DESCRIPTION
## Summary

- Bumps `httpx` constraint from `^0.27` → `^0.28` in `pyproject.toml`

## Why

After merging #29 (version stabilization), `poetry lock` in `caire-services/services/rasa-actions` revealed a new conflict:

```
Because common (0.1.14) depends on httpx (^0.28)
 and rasa-sdk (3.12.0) depends on httpx (^0.27),
 common is incompatible with rasa-sdk.
```

`^0.27` in Poetry means `>=0.27.0, <0.28.0`, which excludes `0.28.x`. `lib/python/common` requires `^0.28`, so the two are incompatible. Latest stable `httpx` is `0.28.1` — there are no breaking changes between 0.27 and 0.28 for this use case.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)