### PR TITLE
chore: regenerate poetry.lock after httpx bump

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# caire-health/rasa-sdk fork
+
+## Dependency changes — mandatory rule
+
+**Whenever `pyproject.toml` is changed, always regenerate `poetry.lock` in the same commit:**
+
+```bash
+poetry lock
+```
+
+Never open a PR with a `pyproject.toml` change without the updated `poetry.lock`.
+
+## Repo context
+
+- This is a fork of `rasahq/rasa-sdk` (the action server framework — separate from the full rasa ML framework)
+- Python `>3.10, <3.13`
+- `caire-services/services/rasa-actions` depends on this repo via git source on `main` branch
+- After merging any change here, run `poetry lock` in `caire-services/services/rasa-actions/` to pick up the new `resolved_reference`
+
+## Version
+
+- Keep `version` in `pyproject.toml` as a stable semver (e.g. `3.12.0`) — never leave it as a pre-release suffix like `.dev2`
+- A pre-release version causes `poetry lock` in dependents to fail with `[BUG] rasa-sdk (x.y.z.devN) is not satisfied`

--- a/poetry.lock
+++ b/poetry.lock
@@ -619,14 +619,14 @@ files = [
 
 [[package]]
 name = "httpx"
-version = "0.27.2"
+version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0"},
-    {file = "httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2"},
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
 ]
 
 [package.dependencies]
@@ -634,7 +634,6 @@ anyio = "*"
 certifi = "*"
 httpcore = "==1.*"
 idna = "*"
-sniffio = "*"
 
 [package.extras]
 brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
@@ -1969,18 +1968,6 @@ test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=
 type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
 
 [[package]]
-name = "sniffio"
-version = "1.3.1"
-description = "Sniff out which async library your code is running under"
-optional = false
-python-versions = ">=3.7"
-groups = ["main", "dev"]
-files = [
-    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
-    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
-]
-
-[[package]]
 name = "thrift"
 version = "0.22.0"
 description = "Python bindings for the Apache Thrift RPC system"
@@ -2412,4 +2399,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.10,<3.13"
-content-hash = "4634cab864edf31cbeb69e84ac750c5d99ebddf156cef90a9d0ea3ca1db6e8db"
+content-hash = "4e45bb178556f787c95f867e7d4d91e72f95f068d71135c879ef5ffd65270561"


### PR DESCRIPTION
## Summary

Regenerates `poetry.lock` to reflect the `httpx ^0.27 → ^0.28` bump from #31 and the version stabilization from #29.

The lock file was behind — it hadn't been regenerated since those two changes landed on main.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)